### PR TITLE
Fixing a message error

### DIFF
--- a/backend/headless/fcbh/clip_vision.py
+++ b/backend/headless/fcbh/clip_vision.py
@@ -97,7 +97,7 @@ def load_clipvision_from_sd(sd, prefix="", convert_keys=False):
     clip = ClipVisionModel(json_config)
     m, u = clip.load_sd(sd)
     if len(m) > 0:
-        print("missing clip vision:", m)
+        print("extra keys clip vision:", m)
     u = set(u)
     keys = list(sd.keys())
     for k in keys:

--- a/backend/headless/fcbh/sd.py
+++ b/backend/headless/fcbh/sd.py
@@ -35,7 +35,7 @@ def load_model_weights(model, sd):
             w = sd.pop(x)
             del w
     if len(m) > 0:
-        print("missing", m)
+        print("extra keys", m)
     return model
 
 def load_clip_weights(model, sd):


### PR DESCRIPTION
Fixes the following message
```
[Fooocus] Downloading control models ...
[Fooocus] Loading control models ...
missing clip vision: ['vision_model.embeddings.position_ids']
```
Source https://github.com/lllyasviel/Fooocus/commit/38b01230f2d86da6e39af25b5c3a7232d9ffe819